### PR TITLE
add version 1.2.0 to appdata.xml

### DIFF
--- a/org.signal.Signal.appdata.xml
+++ b/org.signal.Signal.appdata.xml
@@ -21,6 +21,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.2.0" date="2018-01-24"/>
     <release version="1.1.0" date="2017-12-20"/>
     <release version="1.0.41" date="2017-12-07"/>
     <release version="1.0.40" date="2017-12-05"/>


### PR DESCRIPTION
If these entries are not enforced (the current build doesn't have this and works fine) why do we need the releases?