### PR TITLE
Set usage image as default screenshot

### DIFF
--- a/org.signal.Signal.appdata.xml
+++ b/org.signal.Signal.appdata.xml
@@ -16,7 +16,7 @@
     <screenshot>
       <image type="source">https://signal.org/blog/images/signal-desktop-splash.png</image>
     </screenshot>
-    <screenshot>
+    <screenshot type="default">
       <image type="source">https://signal.org/blog/images/signal-desktop-foucault.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
The first-listed image is a splash screen, which isn’t the best
representation of the application’s functionality.  Set the default
image to be one that shows the application when in use.