### PR TITLE
Update Freedesktop Runtime to 18.08

### DIFF
--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -1,7 +1,7 @@
  {
     "app-id": "org.signal.Signal",
     "base": "io.atom.electron.BaseApp",
-    "base-version": "stable",
+    "base-version": "18.08",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",

--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -3,7 +3,7 @@
     "base": "io.atom.electron.BaseApp",
     "base-version": "stable",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "signal",
     "separate-locales": false,


### PR DESCRIPTION
Exactly what it says on the tin. Hopefully this will fix some weird glitches and performance issues not seen in the uncontained app.