### PR TITLE
Add appindicator support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -16,9 +16,12 @@
         "--share=network",
         "--device=dri",
         "--filesystem=home",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules": [
+        "shared-modules/dbus-glib/dbus-glib-0.110.json",
+        "shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json",
         {
             "name": "signal-desktop",
             "buildsystem": "simple",


### PR DESCRIPTION
Signal has to be started with --use-tray-icon to make it work.

Fixes #73