### PR TITLE
Use zypak-wrapper instead of disabling sandbox

### DIFF
--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -48,7 +48,7 @@
                     "type": "script",
                     "dest-filename": "signal.sh",
                     "commands": [
-                        "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\","
+                        "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
                         "exec zypak-wrapper /app/Signal/signal-desktop \"$@\""
                     ]
                 },

--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -1,6 +1,6 @@
 {
     "app-id": "org.signal.Signal",
-    "base": "io.atom.electron.BaseApp",
+    "base": "org.electronjs.Electron2.BaseApp",
     "base-version": "19.08",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "19.08",

--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -48,7 +48,8 @@
                     "type": "script",
                     "dest-filename": "signal.sh",
                     "commands": [
-                        "exec env TMPDIR=$XDG_CACHE_HOME /app/Signal/signal-desktop --no-sandbox \"$@\""
+                        "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\","
+                        "exec zypak-wrapper /app/Signal/signal-desktop \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
Also move `TMPDIR` to `$XDG_RUNTIME_DIR/app/$FLATPAK_ID` which is better because it's not persistent as original `/tmp` would be.