### PR TITLE
Remove <em> tags from description

### DIFF
--- a/org.signal.Signal.appdata.xml
+++ b/org.signal.Signal.appdata.xml
@@ -10,7 +10,7 @@
   <url type="bugtracker">https://github.com/flathub/org.signal.Signal/issues</url>
   <description>
     <p>
-      <em>To use the Signal desktop app, Signal must first be installed on your phone.</em>
+      To use the Signal desktop app, Signal must first be installed on your phone.
     </p>
     <p>
       Millions of people use Signal every day for free and instantaneous communication 


### PR DESCRIPTION
Emphasized text is not being rendered, so I decided to remove the `<em>` tags for now.

Edit: See https://github.com/flathub/linux-store-frontend/issues/203