### PR TITLE
Stop duplicating shared-modules from baseapp

### DIFF
--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -17,7 +17,8 @@
         "--device=dri",
         "--filesystem=home",
         "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.kde.StatusNotifierWatcher"
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--own-name=org.kde.StatusNotifierItem-2-1"
     ],
     "modules": [
         {

--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -20,8 +20,6 @@
         "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules": [
-        "shared-modules/dbus-glib/dbus-glib-0.110.json",
-        "shared-modules/libappindicator/libappindicator-gtk3-introspection-12.10.json",
         {
             "name": "signal-desktop",
             "buildsystem": "simple",


### PR DESCRIPTION
Those are available in baseapp[1], building them one more time is redundant.

[1] https://github.com/flathub/org.electronjs.Electron2.BaseApp/blob/branch/19.08/org.electronjs.Electron2.BaseApp.yml#L21