### PR TITLE
Use tray icon in the default .desktop file

### DIFF
--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -34,7 +34,7 @@
                 "cp -r usr/* opt/* /app",
                 "rm -rf /app/share/icons/hicolor/1024x1024/",
                 "chmod -R a-s,go+rX,go-w /app/Signal",
-                "sed -i 's|Exec=.*|Exec=signal %U|' /app/share/applications/signal-desktop.desktop",
+                "sed -i 's|Exec=.*|Exec=signal --use-tray-icon %U|' /app/share/applications/signal-desktop.desktop",
                 "install signal.sh /app/bin/signal",
                 "install -Dm644 org.signal.Signal.appdata.xml /app/share/appdata/org.signal.Signal.appdata.xml"
             ],


### PR DESCRIPTION
* Add "--use-tray-icon" flag to the "Exec" of the desktop file.
* Resolve #151.