### PR TITLE
Limit the filesystem to download folder only

### DIFF
--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -17,7 +17,13 @@
         "--device=all",
         "--nodevice=kvm",
         "--nodevice=shm",
+        "--filesystem=xdg-desktop",
+        "--filesystem=xdg-documents",
         "--filesystem=xdg-download",
+        "--filesystem=xdg-music",
+        "--filesystem=xdg-pictures",
+        "--filesystem=xdg-public-share",
+        "--filesystem=xdg-videos",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--own-name=org.kde.StatusNotifierItem-2-1"

--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -17,7 +17,7 @@
         "--device=all",
         "--nodevice=kvm",
         "--nodevice=shm",
-        "--filesystem=home",
+        "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--own-name=org.kde.StatusNotifierItem-2-1"


### PR DESCRIPTION
* Improve sandbox security by change the "--filesystem" flag from
  "home" to "xdg-download". This means Signal can only access the
  XDG Download folder of the user instead of full access to home
  folder.

* Resolve #153.