### PR TITLE
Fix tray icon with KDE Status Notifier

### DIFF
--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -26,7 +26,7 @@
         "--filesystem=xdg-videos",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
-        "--own-name=org.kde.StatusNotifierItem-2-1"
+        "--own-name=org.kde.*"
     ],
     "modules": [
         {


### PR DESCRIPTION
Remove hardcoded reference of `own-name`. This could lead to problems with other apps that have the same own-name.