### PR TITLE
Enable Wayland backend if it's the only choice

### DIFF
--- a/org.signal.Signal.json
+++ b/org.signal.Signal.json
@@ -68,7 +68,12 @@
                     "dest-filename": "signal.sh",
                     "commands": [
                         "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
-                        "exec zypak-wrapper /app/Signal/signal-desktop \"$@\""
+                        "if [ -z \"$DISPLAY\" ] && [ -n \"$WAYLAND_DISPLAY\" ]; then",
+                        "EXTRA_ARGS=\"--enable-features=UseOzonePlatform --ozone-platform=wayland\"",
+                        "else",
+                        "EXTRA_ARGS=\"\"",
+                        "fi",
+                        "exec zypak-wrapper /app/Signal/signal-desktop $EXTRA_ARGS \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
If `DISPLAY` is unset and `WAYLAND_DISPLAY` is set, force using the
wayland backend. This scenario will only happen when a user explicitly
adds overrides to their local Flatpak configuration, e.g.:

    $ cat ~/.local/share/flatpak/overrides/org.signal.Signal
    [Context]
    sockets=wayland;!x11

This changeset has no effect on the default setup, and won't affect
users unless they take manual action to disable the X11 socket.