### PR TITLE
[WIP] Allow env SIGNAL_USE_TRAY_ICON to set tray icon

### DIFF
--- a/org.signal.Signal.metainfo.xml
+++ b/org.signal.Signal.metainfo.xml
@@ -36,6 +36,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="5.37.0" date="2022-03-30"/>
     <release version="5.36.0" date="2022-03-23"/>
     <release version="5.35.0" date="2022-03-10"/>
     <release version="5.34.0" date="2022-03-03"/>

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -12,7 +12,7 @@ finish-args:
   # X11 performance
   - --share=ipc
   # Access to X11 (this is a GUI)
-  - --socket=x11
+  - --socket=fallback-x11
   # Access to wayland
   - --socket=wayland
   # Audio Access

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -59,8 +59,8 @@ modules:
     sources:
       - type: file
         dest-filename: signal-desktop.deb
-        url: https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_5.36.0_amd64.deb
-        sha256: c753d4103abfd01d53d78981b3616e2ad706a491d6388bc702cf21a6da738599
+        url: https://updates.signal.org/desktop/apt/pool/main/s/signal-desktop/signal-desktop_5.37.0_amd64.deb
+        sha256: 867452ffb0993e4d5b6c18e91cb032c0a56edaeee3820de9e7fa7111d933309f
         x-checker-data:
           type: debian-repo
           package-name: signal-desktop

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -2,6 +2,13 @@
 
 EXTRA_ARGS=()
 
+if [[ -n "${SIGNAL_USE_TRAY_ICON+x}" ]];
+then
+    EXTRA_ARGS+=(
+        "--use-tray-icon"
+    )
+fi
+
 if [[ -z "${DISPLAY}" ]] && [[ -n "${WAYLAND_DISPLAY}" ]];
 then
     EXTRA_ARGS+=(

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -2,13 +2,6 @@
 
 EXTRA_ARGS=()
 
-if [[ -n "${SIGNAL_USE_TRAY_ICON+x}" ]];
-then
-    EXTRA_ARGS+=(
-        "--use-tray-icon"
-    )
-fi
-
 if [[ -z "${DISPLAY}" ]] && [[ -n "${WAYLAND_DISPLAY}" ]];
 then
     EXTRA_ARGS+=(
@@ -24,6 +17,23 @@ then
         "--disable-gpu-sandbox"
     )
 fi
+
+# Additional args for tray icon
+if [[ -n "${SIGNAL_USE_TRAY_ICON+x}" ]];
+then
+    EXTRA_ARGS+=(
+        "--use-tray-icon"
+    )
+fi
+if [[ -n "${SIGNAL_START_IN_TRAY+x}" ]];
+then
+    EXTRA_ARGS+=(
+        "--start-in-tray"
+    )
+fi
+
+
+
 
 export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
 exec zypak-wrapper /app/Signal/signal-desktop "${EXTRA_ARGS[@]}" "$@"


### PR DESCRIPTION
This enables users that want the tray icon to pass the environment variable $SIGNAL_USE_TRAY_ICON (either on terminal, desktop file, or flatseal) to have a consistent behavior for the tray icon.

The value can be anything, if it's declared, it will add the `--use-tray-icon` option to the starting command.

(I don't know who will use this anyway, because it's not advertised anywhere.)