### PR TITLE
Change socket to fallback-x11 to remove "Unsafe" warning

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -12,7 +12,7 @@ finish-args:
   # X11 performance
   - --share=ipc
   # Access to X11 (this is a GUI)
-  - --socket=x11
+  - --socket=fallback-x11
   # Access to wayland
   - --socket=wayland
   # Audio Access


### PR DESCRIPTION
Using `--socket=x11` results in GNOME Software showing the app as "Unsafe. Uses a legacy windowing system." Changing this to `--socket=fallback-x11` lets app run on Wayland but can use X11 if Wayland not available