### PR TITLE
Have flatpak set environment variables for greater visability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Note that this is an **inofficial** redistribution.
 ## Options
 You can set the two environment variables:
 
-* `SIGNAL_USE_TRAY_ICON=true`: Enables the tray icon
-* `SIGNAL_START_IN_TRAY=true`: Starts in tray
-* `SIGNAL_USE_WAYLAND=true`: Enables Wayland support
-* `SIGNAL_DISABLE_GPU=true`: Disables GPU acceleration
-* `SIGNAL_DISABLE_GPU_SANDBOX=true`: Disables GPU sandbox
+* `SIGNAL_USE_TRAY_ICON=1`: Enables the tray icon
+* `SIGNAL_START_IN_TRAY=1`: Starts in tray
+* `SIGNAL_USE_WAYLAND=1`: Enables Wayland support
+* `SIGNAL_DISABLE_GPU=1`: Disables GPU acceleration
+* `SIGNAL_DISABLE_GPU_SANDBOX=1`: Disables GPU sandbox
 
 ## Error reporting
 Please only report errors in this repo that are specific to the flatpak version.
@@ -28,22 +28,22 @@ The integration between Chromium, Electron, and Wayland seems broken.
 Adding an additional layer of complexity like Flatpak can't help.
 For now, using this repo with wayland should be regarded as experimental.
 
-Wayland support can be enabled with `SIGNAL_USE_WAYLAND=true` in [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal).
+Wayland support can be enabled with `SIGNAL_USE_WAYLAND=1` in [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal).
 
 Wayland support can also be enabled on the command line:
 
 ```
-$ flatpak override --user --env=SIGNAL_USE_WAYLAND=true org.signal.Signal
+$ flatpak override --user --env=SIGNAL_USE_WAYLAND=1 org.signal.Signal
 ```
 
 GPU acceleration may be need to be disabled:
 
 ```
-$ flatpak override --user --env=SIGNAL_DISABLE_GPU=true org.signal.Signal
+$ flatpak override --user --env=SIGNAL_DISABLE_GPU=1 org.signal.Signal
 ```
 
 Additionally, Nvidia devices may need the GPU sandbox disabled:
 
 ```
-$ flatpak override --user --env=SIGNAL_DISABLE_GPU_SANDBOX=true org.signal.Signal
+$ flatpak override --user --env=SIGNAL_DISABLE_GPU_SANDBOX=1 org.signal.Signal
 ```

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -39,6 +39,11 @@ finish-args:
   - --talk-name=org.freedesktop.portal.Fcitx
   # This is needed for the tray icon
   - --own-name=org.kde.*
+  - --env=SIGNAL_USE_TRAY_ICON=0
+  - --env=SIGNAL_START_IN_TRAY=0
+  - --env=SIGNAL_USE_WAYLAND=0
+  - --env=SIGNAL_DISABLE_GPU=0
+  - --env=SIGNAL_DISABLE_GPU_SANDBOX=0
 
 modules:
   - name: signal-desktop

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -2,32 +2,38 @@
 
 EXTRA_ARGS=()
 
+declare -i SIGNAL_USE_TRAY_ICON="${SIGNAL_USE_TRAY_ICON:-0}"
+declare -i SIGNAL_START_IN_TRAY="${SIGNAL_START_IN_TRAY:-0}"
+declare -i SIGNAL_USE_WAYLAND="${SIGNAL_USE_WAYLAND:-0}"
+declare -i SIGNAL_DISABLE_GPU="${SIGNAL_DISABLE_GPU:-0}"
+declare -i SIGNAL_DISABLE_GPU_SANDBOX="${SIGNAL_DISABLE_GPU_SANDBOX:-0}"
+
 # Additional args for tray icon
-if [[ -n "${SIGNAL_USE_TRAY_ICON+x}" ]]; then
+if [[ "${SIGNAL_USE_TRAY_ICON}" -eq 1 ]]; then
     EXTRA_ARGS+=(
         "--use-tray-icon"
     )
 fi
-if [[ -n "${SIGNAL_START_IN_TRAY+x}" ]]; then
+if [[ "${SIGNAL_START_IN_TRAY}" -eq 1 ]]; then
     EXTRA_ARGS+=(
         "--start-in-tray"
     )
 fi
 
-if [[ -n "${SIGNAL_USE_WAYLAND+x}" && "${XDG_SESSION_TYPE}" == "wayland" ]]; then
+if [[ "${SIGNAL_USE_WAYLAND}" -eq 1 && "${XDG_SESSION_TYPE}" == "wayland" ]]; then
     EXTRA_ARGS+=(
         "--enable-features=WaylandWindowDecorations"
         "--ozone-platform=wayland"
     )
 fi
 
-if [[ -n "${SIGNAL_DISABLE_GPU+x}" ]]; then
+if [[ "${SIGNAL_DISABLE_GPU}" -eq 1 ]]; then
     EXTRA_ARGS+=(
         "--disable-gpu"
     )
 fi
 
-if [[ -n "${SIGNAL_DISABLE_GPU_SANDBOX+x}" ]]; then
+if [[ "${SIGNAL_DISABLE_GPU_SANDBOX}" -eq 1 ]]; then
     EXTRA_ARGS+=(
         "--disable-gpu-sandbox"
     )


### PR DESCRIPTION
The Signal launcher script checks for numerous variables to pass
CLI arguments. This change has them set directly by flatpak so
that they can be visible in frontends like Flatseal. This change
also switches from checking for set variables to instead test
numerical values which is generally more consistent in Bash.