### PR TITLE
Update Freedesktop SDK to 22.08

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -1,8 +1,8 @@
 app-id: org.signal.Signal
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '22.08'
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: signal-desktop
 separate-locales: false


### PR DESCRIPTION
This will help keep Signal up to date with the newest Freedesktop runtime.