### PR TITLE
CI: Only update beta branch automatically

### DIFF
--- a/.github/workflows/update-beta.yaml
+++ b/.github/workflows/update-beta.yaml
@@ -1,16 +1,18 @@
 name: Check for updates
 on:
-  schedule: # for scheduling to work this file must be in the default branch
-    - cron: "0 * * * *" # run every hour
-  workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab 
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch: {}
 
 jobs:
   flatpak-external-data-checker:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'flathub'
 
+    # Only update beta branch: master branch is done by external update checker
     strategy:
       matrix:
-        branch: [ master, beta ] # list all branches to check
+        branch: [ beta ]
     
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +23,6 @@ jobs:
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker
           GIT_COMMITTER_NAME: Flatpak External Data Checker
-          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
           GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/update-beta.yaml
+++ b/.github/workflows/update-beta.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
+      - run: git config --system --add safe.directory /github/workspace
+
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker


### PR DESCRIPTION
The default master branch is already checked by flathub's external data checker.