### PR TITLE
Fix mouse theming issue on wayland

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -47,6 +47,7 @@ finish-args:
   - --env=SIGNAL_USE_WAYLAND=0
   - --env=SIGNAL_DISABLE_GPU=0
   - --env=SIGNAL_DISABLE_GPU_SANDBOX=0
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 modules:
   - name: signal-desktop


### PR DESCRIPTION
Add - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons to fix the mouse theming issue when wayland forced without downside on X11 user

It fix this issue : https://github.com/flathub/org.signal.Signal/issues/375