### PR TITLE
Remove unnecessary permissions (#438)

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -22,14 +22,6 @@ finish-args:
   - --device=all
   # Network Access
   - --share=network
-  # Access to many files
-  - --filesystem=xdg-desktop
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-download
-  - --filesystem=xdg-music
-  - --filesystem=xdg-pictures
-  - --filesystem=xdg-public-share
-  - --filesystem=xdg-videos
   # We need to send notifications
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.IdleMonitor


### PR DESCRIPTION
xdg-portal filepicker already allows the user to choose files, without sharing entire directories to the sandbox