### PR TITLE
fix license

### DIFF
--- a/org.signal.Signal.metainfo.xml
+++ b/org.signal.Signal.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop">
   <id>org.signal.Signal.desktop</id>
   <name>Signal Desktop</name>
-  <project_license>AGPL-3.0</project_license>
+  <project_license>AGPL-3.0-only</project_license>
   <developer_name>Signal Foundation</developer_name>
   <summary>Private messenger</summary>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
The project_license field should contain the SPDX name of the wrapped
application.

Signal uses [AGPLv3](https://opensource.org/license/agpl-v3/) which uses
`AGPL-3.0-only` as SPDX short identifier