### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -34,8 +34,6 @@ finish-args:
   - --talk-name=org.freedesktop.portal.Background
   # Allow advanced input methods
   - --talk-name=org.freedesktop.portal.Fcitx
-  # This is needed for the tray icon
-  - --own-name=org.kde.*
   - --env=SIGNAL_USE_TRAY_ICON=0
   - --env=SIGNAL_START_IN_TRAY=0
   - --env=SIGNAL_USE_WAYLAND=0


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 25.8.1
https://github.com/signalapp/Signal-Desktop/blob/67c1f2af14ed1de74914e3b028835e679561d458/yarn.lock#L9272