### PR TITLE
Remove org.freedesktop.Notifications

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -23,8 +23,6 @@ finish-args:
   - --share=network
   # We need to be able to inhibit sleep
   - --system-talk-name=org.freedesktop.login1
-  # We need to send notifications
-  - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.gnome.Mutter.IdleMonitor
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar


### PR DESCRIPTION
23.08 baseapp uses libnotify 0.8.2 which uses portals for notifications

https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25

Note. if the runtime update gets reverted at any point this needs to be reverted as well.