### PR TITLE
Enable automatic selection of Wayland/X11

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,10 @@ You can set the following environment variables:
 
 * `SIGNAL_USE_TRAY_ICON=1`: Enables the tray icon
 * `SIGNAL_START_IN_TRAY=1`: Starts in tray
-* `SIGNAL_USE_WAYLAND=1`: Enables Wayland support
 * `SIGNAL_DISABLE_GPU=1`: Disables GPU acceleration
 * `SIGNAL_DISABLE_GPU_SANDBOX=1`: Disables GPU sandbox
 
 ## Wayland
-The integration between Chromium, Electron, and Wayland seems broken.
-Adding an additional layer of complexity like Flatpak can't help.
-For now, using this repo with wayland should be regarded as experimental.
-
-Wayland support can be enabled with `SIGNAL_USE_WAYLAND=1` in [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal).
-
-Wayland support can also be enabled on the command line:
-
-```bash
-flatpak override --user --env=SIGNAL_USE_WAYLAND=1 org.signal.Signal
-```
-
 GPU acceleration may be need to be disabled:
 
 ```bash

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -12,7 +12,7 @@ finish-args:
   # X11 performance
   - --share=ipc
   # We need X11
-  - --socket=x11
+  - --socket=fallback-x11
   # Access to wayland
   - --socket=wayland
   # Audio Access
@@ -35,7 +35,6 @@ finish-args:
   - --talk-name=org.freedesktop.portal.Fcitx
   - --env=SIGNAL_USE_TRAY_ICON=0
   - --env=SIGNAL_START_IN_TRAY=0
-  - --env=SIGNAL_USE_WAYLAND=0
   - --env=SIGNAL_DISABLE_GPU=0
   - --env=SIGNAL_DISABLE_GPU_SANDBOX=0
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -4,7 +4,6 @@ EXTRA_ARGS=()
 
 declare -i SIGNAL_USE_TRAY_ICON="${SIGNAL_USE_TRAY_ICON:-0}"
 declare -i SIGNAL_START_IN_TRAY="${SIGNAL_START_IN_TRAY:-0}"
-declare -i SIGNAL_USE_WAYLAND="${SIGNAL_USE_WAYLAND:-0}"
 declare -i SIGNAL_DISABLE_GPU="${SIGNAL_DISABLE_GPU:-0}"
 declare -i SIGNAL_DISABLE_GPU_SANDBOX="${SIGNAL_DISABLE_GPU_SANDBOX:-0}"
 
@@ -17,13 +16,6 @@ fi
 if [[ "${SIGNAL_START_IN_TRAY}" -eq 1 ]]; then
     EXTRA_ARGS+=(
         "--start-in-tray"
-    )
-fi
-
-if [[ "${SIGNAL_USE_WAYLAND}" -eq 1 && "${XDG_SESSION_TYPE}" == "wayland" ]]; then
-    EXTRA_ARGS+=(
-        "--enable-features=WaylandWindowDecorations"
-        "--ozone-platform=wayland"
     )
 fi
 
@@ -44,4 +36,4 @@ echo "Debug: Will run signal with the following arguments: ${EXTRA_ARGS[@]}"
 echo "Debug: Additionally, user gave: $@"
 
 export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
-exec zypak-wrapper /app/Signal/signal-desktop "${EXTRA_ARGS[@]}" "$@"
+exec zypak-wrapper /app/Signal/signal-desktop --ozone-platform-hint=auto "${EXTRA_ARGS[@]}" "$@"


### PR DESCRIPTION
Since Electron 26 flag `--enable-features=WaylandWindowDecorations` is automatically enabled when running on wayland the environment variable is not needed anymore.