### PR TITLE
Remove tray environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ flatpak install flathub org.signal.Signal
 ```
 
 ## Options
+
 You can set the following environment variables:
 
-* `SIGNAL_USE_TRAY_ICON=1`: Enables the tray icon
-* `SIGNAL_START_IN_TRAY=1`: Starts in tray
-* `SIGNAL_USE_WAYLAND=1`: Enables Wayland support
-* `SIGNAL_DISABLE_GPU=1`: Disables GPU acceleration
-* `SIGNAL_DISABLE_GPU_SANDBOX=1`: Disables GPU sandbox
+- `SIGNAL_USE_WAYLAND=1`: Enables Wayland support
+- `SIGNAL_DISABLE_GPU=1`: Disables GPU acceleration
+- `SIGNAL_DISABLE_GPU_SANDBOX=1`: Disables GPU sandbox
 
 ## Wayland
+
 The integration between Chromium, Electron, and Wayland seems broken.
 Adding an additional layer of complexity like Flatpak can't help.
 For now, using this repo with wayland should be regarded as experimental.

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -1,8 +1,8 @@
 id: org.signal.Signal
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: "23.08"
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 command: signal-desktop
 separate-locales: false
@@ -31,8 +31,6 @@ finish-args:
   - --talk-name=com.canonical.indicator.application
   - --talk-name=org.ayatana.indicator.application
   # Environment Variables to control the behavior
-  - --env=SIGNAL_USE_TRAY_ICON=0
-  - --env=SIGNAL_START_IN_TRAY=0
   - --env=SIGNAL_USE_WAYLAND=0
   - --env=SIGNAL_DISABLE_GPU=0
   - --env=SIGNAL_DISABLE_GPU_SANDBOX=0

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -2,23 +2,9 @@
 
 EXTRA_ARGS=()
 
-declare -i SIGNAL_USE_TRAY_ICON="${SIGNAL_USE_TRAY_ICON:-0}"
-declare -i SIGNAL_START_IN_TRAY="${SIGNAL_START_IN_TRAY:-0}"
 declare -i SIGNAL_USE_WAYLAND="${SIGNAL_USE_WAYLAND:-0}"
 declare -i SIGNAL_DISABLE_GPU="${SIGNAL_DISABLE_GPU:-0}"
 declare -i SIGNAL_DISABLE_GPU_SANDBOX="${SIGNAL_DISABLE_GPU_SANDBOX:-0}"
-
-# Additional args for tray icon
-if [[ "${SIGNAL_USE_TRAY_ICON}" -eq 1 ]]; then
-    EXTRA_ARGS+=(
-        "--use-tray-icon"
-    )
-fi
-if [[ "${SIGNAL_START_IN_TRAY}" -eq 1 ]]; then
-    EXTRA_ARGS+=(
-        "--start-in-tray"
-    )
-fi
 
 if [[ "${SIGNAL_USE_WAYLAND}" -eq 1 && "${XDG_SESSION_TYPE}" == "wayland" ]]; then
     EXTRA_ARGS+=(

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -25,7 +25,6 @@ if [[ "${SIGNAL_DISABLE_GPU_SANDBOX}" -eq 1 ]]; then
     )
 fi
 
-
 echo "Debug: Will run signal with the following arguments:" "${EXTRA_ARGS[@]}"
 echo "Debug: Additionally, user gave: $*"
 


### PR DESCRIPTION
Hi, since a few releases it's possible to customize both options through settings GUI so they are no longer needed.