### PR TITLE
Revert "signal-desktop: Update signal-desktop.deb to 7.25.0 (#718)"

### DIFF
--- a/org.signal.Signal.metainfo.xml
+++ b/org.signal.Signal.metainfo.xml
@@ -39,11 +39,8 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="7.25.0" date="2024-09-18">
-      <description></description>
-    </release>
     <release version="7.24.1" date="2024-09-12">
-      <description/>
+      <description></description>
     </release>
     <release version="7.24.0" date="2024-09-12">
       <description/>

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -68,8 +68,8 @@ modules:
     sources:
       - type: file
         dest-filename: signal-desktop.deb
-        url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.25.0_amd64.deb
-        sha256: b565b05c688ca506126ff4d45997592454e1acbaed6910dc791e4afb8bb933a1
+        url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_7.24.1_amd64.deb
+        sha256: 104464ca98fdd86a757154a8757c73894dda5ac18360f0fcdc1da7746d66411d
         x-checker-data:
           type: debian-repo
           package-name: signal-desktop


### PR DESCRIPTION
This reverts commit ac1ca491ad3c56894d49a9ba6470030301f108ab.

The file portals are not used with this version.