### PR TITLE
Use freedesktop 24.08 SDK & runtime

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -1,8 +1,8 @@
 id: org.signal.Signal
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: signal-desktop
 separate-locales: false


### PR DESCRIPTION
Let's make use of the updated runtime & SDKs:
https://discourse.flathub.org/t/freedesktop-sdk-24-08-0-released/7630

Changes were tested and found working without any issues on my side, but further testing would be highly appreciated!