### PR TITLE
Revert "Fix capitalization"

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -25,7 +25,7 @@ finish-args:
   - --talk-name=org.freedesktop.PowerManagement
   - --talk-name=org.freedesktop.ScreenSaver
   # Secrets storage
-  - --talk-name=org.freedesktop.Secrets
+  - --talk-name=org.freedesktop.secrets
   # These are for notifications/tray icons
   - --talk-name=org.gnome.Mutter.IdleMonitor
   - --talk-name=org.kde.StatusNotifierWatcher


### PR DESCRIPTION
This reverts commit f88079a969bfcfbf33af95123418e632c44d2371.

The name is in lowercase:

```
dbus-send --print-reply --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.ListNames|grep secrets
      string "org.freedesktop.secrets"
```