### PR TITLE
Migrate from `signal.desktop` to `org.signal.Signal.desktop`

### DIFF
--- a/org.signal.Signal.metainfo.xml
+++ b/org.signal.Signal.metainfo.xml
@@ -38,6 +38,9 @@
       <caption>Typical view of the window (Windows version)</caption>
     </screenshot>
   </screenshots>
+  <provides>
+    <id>signal.desktop</id>
+  </provides>
   <releases>
     <release version="7.24.1" date="2024-09-12">
       <description></description>

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -67,6 +67,8 @@ modules:
       - install -Dm0644 "${FLATPAK_ID}.metainfo.xml" "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
       - desktop-file-edit --set-key=Exec --set-value='signal-desktop %U' "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
       - desktop-file-edit --set-key=Icon --set-value="${FLATPAK_ID}" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+      - desktop-file-edit --set-key=X-Flatpak-RenamedFrom --set-value='signal.desktop;' "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+      - patch-desktop-filename "${FLATPAK_DEST}/Signal/resources/app.asar"
     sources:
       - type: file
         dest-filename: signal-desktop.deb


### PR DESCRIPTION
Ideally, upstream will also migrate to `org.signal.Signal.desktop`. This fixes task manager icons on KDE Plasma 6.1.5.

AppStream gained `<provides><id>…` per a recommendation from <https://blogs.gnome.org/hughsie/2019/04/23/remember-the-extra-metadata-if-you-change-a-desktop-id/>.