### PR TITLE
Fix condition to show encryption warning

### DIFF
--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -55,7 +55,7 @@ esac
 # - if the user chose basic (this is the default)
 # - and Signal starts for the first time
 if [[ "${SIGNAL_PASSWORD_STORE}" == "basic" ]]; then
-    if [[ ! -f "${XDG_CONFIG_HOME}/Signal/config.json" ]]; then
+    if [[ ! -f "${XDG_CONFIG_HOME:-$HOME/.var/app/org.signal.Signal/config}/Signal/config.json" ]]; then
         show_encryption_warning
     fi
 fi


### PR DESCRIPTION
Although the [official Flatpak documentation about XDG base directories](https://docs.flatpak.org/en/latest/conventions.html#xdg-base-directories) states that

> These environment variables are always set by flatpak and override any host values. 

`XDG_CONFIG_HOME` can be unset, apparently?

This fixes https://github.com/flathub/org.signal.Signal/issues/751 (hopefully).

Please note that I don't have much experience with Flatpak internals, so please thoroughly review this change.