### PR TITLE
Only warn if SIGNAL_PASSWORD_STORE is unset.

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -35,7 +35,6 @@ finish-args:
   # Environment Variables to control the behavior
   - --env=SIGNAL_DISABLE_GPU=0
   - --env=SIGNAL_DISABLE_GPU_SANDBOX=0
-  - --env=SIGNAL_PASSWORD_STORE=basic
   # Use same mouse cursors as host
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -36,6 +36,13 @@ if ((${SIGNAL_USE_WAYLAND:-0})); then
     export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-auto}"
 fi
 
+# Warn the user about plaintext password
+# - if the user chose basic (this is the default)
+# - and Signal starts for the first time
+if [[ -z "${SIGNAL_PASSWORD_STORE-}" && ! -f "${XDG_CONFIG_HOME}/Signal/config.json" ]]; then
+    show_encryption_warning
+fi
+
 declare -r SIGNAL_PASSWORD_STORE="${SIGNAL_PASSWORD_STORE:-basic}"
 
 case "${SIGNAL_PASSWORD_STORE}" in
@@ -50,15 +57,6 @@ case "${SIGNAL_PASSWORD_STORE}" in
         exit 1
         ;;
 esac
-
-# Warn the user about plaintext password
-# - if the user chose basic (this is the default)
-# - and Signal starts for the first time
-if [[ "${SIGNAL_PASSWORD_STORE}" == "basic" ]]; then
-    if [[ ! -f "${XDG_CONFIG_HOME}/Signal/config.json" ]]; then
-        show_encryption_warning
-    fi
-fi
 
 if [[ "${SIGNAL_DISABLE_GPU}" -eq 1 ]]; then
     EXTRA_ARGS+=(


### PR DESCRIPTION
If a user already has set a flatpak override defining `SIGNAL_PASSWORD_STORE` to `basic`, there is no point showing them a warning.