### PR TITLE
Use correct desktop file name

### DIFF
--- a/org.signal.Signal.metainfo.xml
+++ b/org.signal.Signal.metainfo.xml
@@ -39,7 +39,7 @@
     </screenshot>
   </screenshots>
   <provides>
-    <id>signal.desktop</id>
+    <id>signal-desktop.desktop</id>
   </provides>
   <releases>
     <release version="7.24.1" date="2024-09-12">

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -47,28 +47,18 @@ modules:
         bsdtar -Oxf signal-desktop.deb 'data.tar.xz' |
           bsdtar -xf - \
             --exclude='./usr/share/doc'
+      - mv "opt/Signal" "${FLATPAK_DEST}/Signal"
+      - install -Dm0644 "usr/share/applications/signal-desktop.desktop" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+
       - |
-        if [ -d "opt/Signal" ]; then
-          mv "opt/Signal" "${FLATPAK_DEST}/Signal"
-          BETA_SUFFIX=""
-        elif [ -d "opt/Signal Beta" ]; then
-          mv "opt/Signal Beta" "${FLATPAK_DEST}/Signal"
-          ln -s "${FLATPAK_DEST}/Signal/signal-desktop-beta" "${FLATPAK_DEST}/Signal/signal-desktop"
-          BETA_SUFFIX="-beta"
-        else
-          exit 1
-        fi
-
-        install -Dm0644 "usr/share/applications/signal-desktop${BETA_SUFFIX}.desktop" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
-
         for size in 16 24 32 48 64 128 256 512; do
-          install -Dm0644 "usr/share/icons/hicolor/${size}x${size}/apps/signal-desktop${BETA_SUFFIX}.png" "${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png"
+          install -Dm0644 "usr/share/icons/hicolor/${size}x${size}/apps/signal-desktop.png" "${FLATPAK_DEST}/share/icons/hicolor/${size}x${size}/apps/${FLATPAK_ID}.png"
         done
       - install -Dm0755 signal-desktop.sh "${FLATPAK_DEST}/bin/signal-desktop"
       - install -Dm0644 "${FLATPAK_ID}.metainfo.xml" "${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
       - desktop-file-edit --set-key=Exec --set-value='signal-desktop %U' "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
       - desktop-file-edit --set-key=Icon --set-value="${FLATPAK_ID}" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
-      - desktop-file-edit --set-key=X-Flatpak-RenamedFrom --set-value='signal.desktop;' "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
+      - desktop-file-edit --set-key=X-Flatpak-RenamedFrom --set-value='signal-desktop.desktop;' "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
       - patch-desktop-filename "${FLATPAK_DEST}/Signal/resources/app.asar"
     sources:
       - type: file


### PR DESCRIPTION
Upstream calls their desktop file `signal-desktop.desktop`