### PR TITLE
Allow filesystem=host (show information once)

### DIFF
--- a/org.signal.Signal.metainfo.xml
+++ b/org.signal.Signal.metainfo.xml
@@ -34,7 +34,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://web.archive.org/web/20240219132433if_/https://signal.org/assets/images/screenshots/download-desktop-windows.png</image>
+      <image type="source">https://signal.org/assets/images/screenshots/download-desktop-windows.png</image>
       <caption>Typical view of the window (Windows version)</caption>
     </screenshot>
   </screenshots>

--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -15,6 +15,8 @@ finish-args:
   - --socket=wayland
   # Audio Access
   - --socket=pulseaudio
+  # Access to all files
+  - --filesystem=host
   # All devices (camera, microphone for calls)
   - --device=all
   # Network Access

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -26,6 +26,30 @@ EOF
     fi
 }
 
+explain_filesystem_access() {
+    read -r -d '|' MESSAGE <<EOF
+Signal is being launched with the <b>filesystem=host</b> option to allow access to the host filesystem.
+This is currently required because Electron decided to break the portals (temporarily):
+<a href="https://github.com/flathub/org.signal.Signal/issues/719">flathub/org.signal.Signal#719</a>
+and
+<a href="https://github.com/electron/electron/issues/43819#issuecomment-2383104130">electron/electron#43819</a>
+
+If you disagree with host system access, please use Flatseal (or the commandline) to restrict the permissions
+to the only the directories you want Signal to access for reading and writing files.
+
+Press <b>Yes</b> to proceed with <b>filesystem=host</b> or <b>No</b> to <b>exit</b>.
+
+This information is shown only once. If you press <b>No</b>, Signal will exit.
+The next time you start Signal, you will not see this message and <b>filesystem=host</b> will be used.
+EOF
+    if [[ ! "$(zenity --question --no-wrap --icon-name=info --title "Information about full file system access" --text "${MESSAGE}")" ]]; then
+        echo "Debug: Abort as user pressed cancel"
+        return 1
+    fi
+
+    return 0
+}
+
 EXTRA_ARGS=()
 
 declare -i SIGNAL_DISABLE_GPU="${SIGNAL_DISABLE_GPU:-0}"
@@ -39,16 +63,16 @@ fi
 declare -r SIGNAL_PASSWORD_STORE="${SIGNAL_PASSWORD_STORE:-basic}"
 
 case "${SIGNAL_PASSWORD_STORE}" in
-    basic | gnome-libsecret | kwallet | kwallet5 | kwallet6)
-        echo "Debug: Using password store: ${SIGNAL_PASSWORD_STORE}"
-        EXTRA_ARGS=(
-            "--password-store=${SIGNAL_PASSWORD_STORE}"
-        )
-        ;;
-    *)
-        echo "Error: SIGNAL_PASSWORD_STORE (${SIGNAL_PASSWORD_STORE}) must be one of the following: basic, gnome-libsecret, kwallet, kwallet5, kwallet6"
-        exit 1
-        ;;
+basic | gnome-libsecret | kwallet | kwallet5 | kwallet6)
+    echo "Debug: Using password store: ${SIGNAL_PASSWORD_STORE}"
+    EXTRA_ARGS=(
+        "--password-store=${SIGNAL_PASSWORD_STORE}"
+    )
+    ;;
+*)
+    echo "Error: SIGNAL_PASSWORD_STORE (${SIGNAL_PASSWORD_STORE}) must be one of the following: basic, gnome-libsecret, kwallet, kwallet5, kwallet6"
+    exit 1
+    ;;
 esac
 
 # Warn the user about plaintext password
@@ -57,6 +81,19 @@ esac
 if [[ "${SIGNAL_PASSWORD_STORE}" == "basic" ]]; then
     if [[ ! -f "${XDG_CONFIG_HOME}/Signal/config.json" ]]; then
         show_encryption_warning
+    fi
+fi
+
+# Explain filesystem=host upon the first run
+EXPLAIN_FILESYSTEM_HOST_FILE="${XDG_CONFIG_HOME}/Signal/explanation-filesystem-access-shown"
+if [[ ! -f "${EXPLAIN_FILESYSTEM_HOST_FILE}" ]]; then
+    acceptAccess="$(explain_filesystem_access)"
+    touch "${EXPLAIN_FILESYSTEM_HOST_FILE}"
+    if [[ "${acceptAccess}" == "0" ]]; then
+        echo "Debug: User accepted filesystem=host explanation"
+    else
+        echo "Debug: Abort as user pressed cancel on filesystem=host explanation"
+        exit 1
     fi
 fi
 

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -26,28 +26,21 @@ EOF
     fi
 }
 
-explain_filesystem_access() {
+user_accepted_filesystem_access() {
     read -r -d '|' MESSAGE <<EOF
-Signal is being launched with the <b>filesystem=host</b> option to allow access to the host filesystem.
+By default, Signal is being launched with the <b>filesystem=host</b> option to allow access to the host filesystem.
 This is currently required because Electron decided to break the portals (temporarily):
-<a href="https://github.com/flathub/org.signal.Signal/issues/719">flathub/org.signal.Signal#719</a>
-and
-<a href="https://github.com/electron/electron/issues/43819#issuecomment-2383104130">electron/electron#43819</a>
+See <a href="https://github.com/flathub/org.signal.Signal/issues/719">flathub/org.signal.Signal#719</a> and <a href="https://github.com/electron/electron/issues/43819#issuecomment-2383104130">electron/electron#43819</a>
 
-If you disagree with host system access, please use Flatseal (or the commandline) to restrict the permissions
-to the only the directories you want Signal to access for reading and writing files.
+If you disagree with host filesystem access, please use Flatseal (or the commandline) to restrict the permissions
+to the only those directories you want Signal to be able access for reading and writing files.
 
 Press <b>Yes</b> to proceed with <b>filesystem=host</b> or <b>No</b> to <b>exit</b>.
 
-This information is shown only once. If you press <b>No</b>, Signal will exit.
-The next time you start Signal, you will not see this message and <b>filesystem=host</b> will be used.
+If you manually changed the permissions with Flatseal already, you can press <b>Yes</b> to continue.
 EOF
-    if [[ ! "$(zenity --question --no-wrap --icon-name=info --title "Information about full file system access" --text "${MESSAGE}")" ]]; then
-        echo "Debug: Abort as user pressed cancel"
-        return 1
-    fi
-
-    return 0
+    zenity --question --no-wrap --icon-name=info --title "Information about full file system access" --text "${MESSAGE}"
+    return $?
 }
 
 EXTRA_ARGS=()
@@ -85,14 +78,13 @@ if [[ "${SIGNAL_PASSWORD_STORE}" == "basic" ]]; then
 fi
 
 # Explain filesystem=host upon the first run
-EXPLAIN_FILESYSTEM_HOST_FILE="${XDG_CACHE_HOME}/signal-explanation-filesystem-access-shown"
+EXPLAIN_FILESYSTEM_HOST_FILE="${XDG_CACHE_HOME}/signal-user-accepted-filesystem-access"
 if [[ ! -f "${EXPLAIN_FILESYSTEM_HOST_FILE}" ]]; then
-    acceptAccess="$(explain_filesystem_access)"
-    touch "${EXPLAIN_FILESYSTEM_HOST_FILE}"
-    if [[ "${acceptAccess}" == "0" ]]; then
-        echo "Debug: User accepted filesystem=host explanation"
+    if user_accepted_filesystem_access; then
+        echo "Debug: User accepted filesystem=host explanation or already changed permissions."
+        touch "${EXPLAIN_FILESYSTEM_HOST_FILE}"
     else
-        echo "Debug: Abort as user pressed cancel on filesystem=host explanation"
+        echo "Debug: Abort as user pressed cancel on filesystem=host explanation."
         exit 1
     fi
 fi

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -85,7 +85,7 @@ if [[ "${SIGNAL_PASSWORD_STORE}" == "basic" ]]; then
 fi
 
 # Explain filesystem=host upon the first run
-EXPLAIN_FILESYSTEM_HOST_FILE="${XDG_CONFIG_HOME}/Signal/explanation-filesystem-access-shown"
+EXPLAIN_FILESYSTEM_HOST_FILE="${XDG_CACHE_HOME}/signal-explanation-filesystem-access-shown"
 if [[ ! -f "${EXPLAIN_FILESYSTEM_HOST_FILE}" ]]; then
     acceptAccess="$(explain_filesystem_access)"
     touch "${EXPLAIN_FILESYSTEM_HOST_FILE}"


### PR DESCRIPTION
This is necessary because Electron broke the portals.

Also, adding specific folders like xdg-downloads, xdg-pictures, xdg-videos, and such will never satisfy everybody.