### PR TITLE
Signal should be allowed to access only to public share folder

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -16,7 +16,7 @@ finish-args:
   # Audio Access
   - --socket=pulseaudio
   # Access to all files
-  - --filesystem=host
+  - --filesystem=xdg-public-share
   # All devices (camera, microphone for calls)
   - --device=all
   # Network Access

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -26,23 +26,6 @@ EOF
     fi
 }
 
-user_accepted_filesystem_access() {
-    read -r -d '|' MESSAGE <<EOF
-By default, Signal is being launched with the <b>filesystem=host</b> option to allow access to the host filesystem.
-This is currently required because Electron decided to break the portals (temporarily):
-See <a href="https://github.com/flathub/org.signal.Signal/issues/719">flathub/org.signal.Signal#719</a> and <a href="https://github.com/electron/electron/issues/43819#issuecomment-2383104130">electron/electron#43819</a>
-
-If you disagree with host filesystem access, please use Flatseal (or the commandline) to restrict the permissions
-to the only those directories you want Signal to be able access for reading and writing files.
-
-Press <b>Yes</b> to proceed with <b>filesystem=host</b> or <b>No</b> to <b>exit</b>.
-
-If you manually changed the permissions with Flatseal already, you can press <b>Yes</b> to continue.
-EOF
-    zenity --question --no-wrap --icon-name=info --title "Information about full file system access" --text "${MESSAGE}"
-    return $?
-}
-
 EXTRA_ARGS=()
 
 declare -i SIGNAL_DISABLE_GPU="${SIGNAL_DISABLE_GPU:-0}"
@@ -74,18 +57,6 @@ esac
 if [[ "${SIGNAL_PASSWORD_STORE}" == "basic" ]]; then
     if [[ ! -f "${XDG_CONFIG_HOME}/Signal/config.json" ]]; then
         show_encryption_warning
-    fi
-fi
-
-# Explain filesystem=host upon the first run
-EXPLAIN_FILESYSTEM_HOST_FILE="${XDG_CACHE_HOME}/signal-user-accepted-filesystem-access"
-if [[ ! -f "${EXPLAIN_FILESYSTEM_HOST_FILE}" ]]; then
-    if user_accepted_filesystem_access; then
-        echo "Debug: User accepted filesystem=host explanation or already changed permissions."
-        touch "${EXPLAIN_FILESYSTEM_HOST_FILE}"
-    else
-        echo "Debug: Abort as user pressed cancel on filesystem=host explanation."
-        exit 1
     fi
 fi
 


### PR DESCRIPTION
Related to: https://github.com/flathub/org.signal.Signal/issues/719

Could you double-check if "Gnome file-picker" has any problem accessing this folder in order to upload/download files?