### PR TITLE
Update environment variables for Wayland support

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -39,6 +39,8 @@ finish-args:
   - --env=SIGNAL_DISABLE_GPU=0
   - --env=SIGNAL_DISABLE_GPU_SANDBOX=0
   - --env=SIGNAL_PASSWORD_STORE=basic
+  # Environment variable set to make Signal prefer Wayland when available
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
   # Use same mouse cursors as host
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 


### PR DESCRIPTION
This adds ELECTRON_OZONE_PLATFORM_HINT=auto as is done in some other Electron-based flatpaks (e.g., Standard Notes) to allow Electron to select Wayland when available.

See also: https://github.com/flathub/org.standardnotes.standardnotes/blob/ded7971cff96644b5a194b3d583ae4238bde2662/org.standardnotes.standardnotes.yml#L23