### PR TITLE
Revert to runtime 24.08

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -1,8 +1,8 @@
 id: org.signal.Signal
 base: org.electronjs.Electron2.BaseApp
-base-version: '25.08'
+base-version: '24.08'
 runtime: org.freedesktop.Platform
-runtime-version: '25.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: signal-desktop
 separate-locales: false


### PR DESCRIPTION
fix #949 
Because of an [upstream bug](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1900) with the 25.08 runtime, Signal is unable to display CJK characters. I suggest reverting to 24.08 until this is fixed.