### PR TITLE
Remove `ELECTRON_OZONE_PLATFORM_HINT` and work around Electron's broken wayland detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ flatpak install flathub org.signal.Signal
 
 You can set the following environment variables:
 
-- `ELECTRON_OZONE_PLATFORM_HINT=auto`: Enables Wayland support
 - `SIGNAL_DISABLE_GPU=1`: Disables GPU acceleration
 - `SIGNAL_DISABLE_GPU_SANDBOX=1`: Disables GPU sandbox
 - `SIGNAL_PASSWORD_STORE`: Selects where the database key is stored. Valid options are:
@@ -26,19 +25,7 @@ You can set the following environment variables:
 	- `kwallet5` for kde5
 	- `kwallet6` for kde6
 
-## Wayland
-
-The integration between Chromium, Electron, and Wayland seems broken.
-Adding an additional layer of complexity like Flatpak can't help.
-For now, using this repo with wayland should be regarded as experimental.
-
-Wayland support can be enabled with `ELECTRON_OZONE_PLATFORM_HINT=auto` in [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal).
-
-Wayland support can also be enabled on the command line:
-
-```bash
-flatpak override --user --env=ELECTRON_OZONE_PLATFORM_HINT=auto org.signal.Signal
-```
+## Troubleshooting
 
 GPU acceleration may be need to be disabled:
 

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -31,11 +31,6 @@ EXTRA_ARGS=()
 declare -i SIGNAL_DISABLE_GPU="${SIGNAL_DISABLE_GPU:-0}"
 declare -i SIGNAL_DISABLE_GPU_SANDBOX="${SIGNAL_DISABLE_GPU_SANDBOX:-0}"
 
-# only kept for backward compatibility
-if ((${SIGNAL_USE_WAYLAND:-0})); then
-    export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-auto}"
-fi
-
 declare -r SIGNAL_PASSWORD_STORE="${SIGNAL_PASSWORD_STORE:-basic}"
 
 case "${SIGNAL_PASSWORD_STORE}" in
@@ -51,7 +46,8 @@ basic | gnome-libsecret | kwallet | kwallet5 | kwallet6)
     ;;
 esac
 
-if [[ "${ELECTRON_OZONE_PLATFORM_HINT}" == "auto" || "${ELECTRON_OZONE_PLATFORM_HINT}" == "wayland" ]]; then
+# add wayland specific command line arguments
+if [[ ${XDG_SESSION_TYPE:-} == "wayland" ]]; then
     EXTRA_ARGS+=("--enable-wayland-ime" "--wayland-text-input-version=3")
 fi
 

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -49,6 +49,11 @@ esac
 # add wayland specific command line arguments
 if [[ ${XDG_SESSION_TYPE:-} == "wayland" ]]; then
     EXTRA_ARGS+=("--enable-wayland-ime" "--wayland-text-input-version=3")
+
+    # work around electron's broken wayland detection
+    # TODO: remove when signal uses an electron release that includes the fix
+    # https://github.com/electron/electron/pull/48301
+    EXTRA_ARGS+=("--ozone-platform=wayland")
 fi
 
 # Warn the user about plaintext password


### PR DESCRIPTION
Chromium 140, on which Electron 38 is based, uses the Wayland Ozone backend by default. In this context, the Chromium command line argument `--ozone-platform-hint` has been removed as it is no longer needed. Due to this removal, the Electron environment variable `ELECTRON_OZONE_PLATFORM_HINT` no longer has any effect.

Upstream issue: https://github.com/electron/electron/issues/48001

Unfortunately, the Wayland detection is broken in the Electron 38 release which is used by the latest Signal release. It is already fixed upstream (https://github.com/electron/electron/pull/48301), but until Signal has upgraded to a release with the fix, we need a workaround.

Fixes #962