### PR TITLE
Remove unnecessary environment variable `ELECTRON_OZONE_PLATFORM_HINT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The app will be installed as `Signal Beta`. The stable and beta release can be i
 
 You can set the following environment variables:
 
-- `SIGNAL_USE_WAYLAND=1`: Enables Wayland support
 - `SIGNAL_DISABLE_GPU=1`: Disables GPU acceleration
 - `SIGNAL_DISABLE_GPU_SANDBOX=1`: Disables GPU sandbox
 - `SIGNAL_PASSWORD_STORE`: Selects where the database key is stored. Valid options are:
@@ -32,19 +31,7 @@ You can set the following environment variables:
 	- `kwallet5` for kde5
 	- `kwallet6` for kde6
 
-## Wayland
-
-The integration between Chromium, Electron, and Wayland seems broken.
-Adding an additional layer of complexity like Flatpak can't help.
-For now, using this repo with wayland should be regarded as experimental.
-
-Wayland support can be enabled with `SIGNAL_USE_WAYLAND=1` in [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal).
-
-Wayland support can also be enabled on the command line:
-
-```bash
-flatpak override --user --env=SIGNAL_USE_WAYLAND=1 org.signal.Signal
-```
+## Troubleshooting
 
 GPU acceleration may be need to be disabled:
 

--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -31,11 +31,6 @@ EXTRA_ARGS=()
 declare -i SIGNAL_DISABLE_GPU="${SIGNAL_DISABLE_GPU:-0}"
 declare -i SIGNAL_DISABLE_GPU_SANDBOX="${SIGNAL_DISABLE_GPU_SANDBOX:-0}"
 
-# only kept for backward compatibility
-if ((${SIGNAL_USE_WAYLAND:-0})); then
-    export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-auto}"
-fi
-
 declare -r SIGNAL_PASSWORD_STORE="${SIGNAL_PASSWORD_STORE:-basic}"
 
 case "${SIGNAL_PASSWORD_STORE}" in
@@ -51,7 +46,8 @@ basic | gnome-libsecret | kwallet | kwallet5 | kwallet6)
     ;;
 esac
 
-if [[ "${ELECTRON_OZONE_PLATFORM_HINT}" == "auto" || "${ELECTRON_OZONE_PLATFORM_HINT}" == "wayland" ]]; then
+# add wayland specific command line arguments
+if [[ ${XDG_SESSION_TYPE:-} == "wayland" ]]; then
     EXTRA_ARGS+=("--enable-wayland-ime" "--wayland-text-input-version=3")
 fi
 


### PR DESCRIPTION
Chromium 140, on which Electron 38 is based, uses the Wayland Ozone backend by default. In this context, the Chromium command line argument `--ozone-platform-hint` has been removed as it is no longer needed. Due to this removal, the Electron environment variable `ELECTRON_OZONE_PLATFORM_HINT` no longer has any effect.

Upstream issue: https://github.com/electron/electron/issues/48001