### PR TITLE
Remove workaround for Electron's broken wayland detection

### DIFF
--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -49,11 +49,6 @@ esac
 # add wayland specific command line arguments
 if [[ ${XDG_SESSION_TYPE:-} == "wayland" ]]; then
     EXTRA_ARGS+=("--enable-wayland-ime" "--wayland-text-input-version=3")
-
-    # work around electron's broken wayland detection
-    # TODO: remove when signal uses an electron release that includes the fix
-    # https://github.com/electron/electron/pull/48301
-    EXTRA_ARGS+=("--ozone-platform=wayland")
 fi
 
 # Warn the user about plaintext password


### PR DESCRIPTION
Signal 7.73.0 uses Electron 38.2.0 which includes the fix for the broken wayland detection (https://github.com/electron/electron/pull/48309).