### PR TITLE
Use libsecret from base app

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -43,29 +43,6 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
 modules:
-  - name: libsecret
-    buildsystem: meson
-    config-opts:
-      - -Dmanpage=false
-      - -Dcrypto=disabled
-      - -Dvapi=false
-      - -Dgtk_doc=false
-      - -Dintrospection=false
-      - -Dbash_completion=disabled
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/man
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.7.tar.xz
-        sha256: 6b452e4750590a2b5617adc40026f28d2f4903de15f1250e1d1c40bfd68ed55e
-        x-checker-data:
-          type: anitya
-          project-id: 13150
-          url-template: https://download.gnome.org/sources/libsecret/$major.$minor/libsecret-$version.tar.xz
-
   - name: signal-desktop
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Branch 25.08 of the base app `org.electronjs.Electron2.BaseApp` already provides libsecret with the crypto backend disabled.

Ref: https://github.com/flathub/org.electronjs.Electron2.BaseApp/commit/24e075eb32f6d638874f7d5533337350a3eb0a0d