### PR TITLE
Remove workaround for asar re-packing bug

### DIFF
--- a/signal-desktop.sh
+++ b/signal-desktop.sh
@@ -79,8 +79,5 @@ echo "Debug: Additionally, user gave: $*"
 
 export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
 
-# Chromium leaks tmpfiles, cleanup any old ones
-find "${TMPDIR}" -name ".org.chromium.Chromium.*" -delete
-
 # Finally launch signal
 exec zypak-wrapper "/app/Signal/signal-desktop" "${EXTRA_ARGS[@]}" "$@"


### PR DESCRIPTION
Prior to #1061, the underlying Electron/Chromium runtime would leak binaries in `/run/user/[uid]/app/org.signal.Signal`, because of flathub/org.electronjs.Electron2.BaseApp#65. This caused issues like #751 and #813, for which this workaround was implemented.

However, since the runtime was fixed recently, this is no longer the case, so the workaround is no longer needed.