### PR TITLE
Synchronize beta versions for amd64/aarch

### DIFF
--- a/org.signal.Signal.yaml
+++ b/org.signal.Signal.yaml
@@ -68,26 +68,22 @@ modules:
         dest-filename: signal-desktop-beta.deb
         url: https://updates.signal.org/desktop/apt/pool/s/signal-desktop-beta/signal-desktop-beta_8.23.0-beta.1_amd64.deb
         sha256: 5310ee6b9ae05f80af80195863b364e53f815f3e05cf32737d1db288454c9aa5
+        only-arches: [x86_64]
         x-checker-data:
-          type: debian-repo
-          package-name: signal-desktop-beta
-          root: https://updates.signal.org/desktop/apt
-          dist: xenial
-          component: main
-        only-arches:
-          - x86_64
+          type: anitya
+          project-id: 14802
+          stable-only: false
+          url-template: https://updates.signal.org/desktop/apt/pool/s/signal-desktop-beta/signal-desktop-beta_${version}_amd64.deb
       - type: file
         dest-filename: signal-desktop-beta.deb
         url: https://updates.signal.org/desktop/apt-arm64/pool/s/signal-desktop-beta/signal-desktop-beta_8.23.0-beta.1_arm64.deb
         sha256: f37f44892d1d8dced2bf7374b97cf8666c9325551076a001d9b2c4e4ab692482
+        only-arches: [aarch64]
         x-checker-data:
-          type: debian-repo
-          package-name: signal-desktop-beta
-          root: https://updates.signal.org/desktop/apt-arm64
-          dist: stable
-          component: main
-        only-arches:
-          - aarch64
+          type: anitya
+          project-id: 14802
+          stable-only: false
+          url-template: https://updates.signal.org/desktop/apt-arm64/pool/s/signal-desktop-beta/signal-desktop-beta_${version}_arm64.deb
       - type: file
         path: signal-desktop.sh
       - type: file


### PR DESCRIPTION
Looks like signal's repo isn't updated fast enough so our update checker misses the aarch version and only updates amd64.
This PR tries to synchronize these two.